### PR TITLE
feat(post)!: provide more manager options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,89 +1,23 @@
-<div align="center">
-<a href="https://github.com/nx-space" target="_blank" rel="noopener noreferrer"><img width="100" src="https://avatars.githubusercontent.com/u/106414194" alt="NEXT logo"></a>
-<h1>NextSpace Server v1.x <small><code>WIP</code></small></h1>
-  <p>
-  the RESTful API service for NEXT Space, powered by @nestjs. 
-  </p>
-  <p>
-    NEXT 博客空间的核心API服务，基于 @nestjs <em><strong>无限进步！</strong></em>
-  </p>
-  <a href="https://wakatime.com/badge/github/nx-space/core"><img src="https://wakatime.com/badge/github/nx-space/core.svg" alt="wakatime"></a>
-<img src="https://img.shields.io/github/package-json/v/nx-space/core" referrerpolicy="no-referrer" alt="version">
+# NextSpace Server v1.x `Alpha`
+
+the RESTful API service for NEXT Space, powered by @nestjs. 
+
+NEXT 博客空间的核心API服务，基于 @nestjs **_无限进步！_**
+
+<img src="https://img.shields.io/github/package-json/v/nx-space/core" referrerpolicy="no-referrer" alt="version"><a href="https://wakatime.com/badge/github/nx-space/core"><img src="https://wakatime.com/badge/github/nx-space/core.svg" alt="wakatime"></a>
 <a href="https://github.com/nx-space/core/actions/workflows/build.yml"><img src="https://github.com/nx-space/core/actions/workflows/build.yml/badge.svg"></a>
-</div>
-
-
-
-<br />
-
-![Alt](https://repobeats.axiom.co/api/embed/c41f4aa5c6264c1db4ddd6c2120c0fca64dabcea.svg "Repobeats analytics image")
-
-<br />
-
 
 ## 开始使用
 
-**_nx-server 依赖于 NodeJS, MongoDB 和 Redis 环境_**
+**_nx-core 依赖于 NodeJS 14 (at least), MongoDB 和 Redis 环境_**
 
-Work in process 正在开发当中
-
-~~[Documentation 文档](https://nx-docs.iucky.cn)｜ [Development Live Demo](htttps://gs-server.vercel.app)~~
-
-
-## NEXT Space 的优点
-
-- **开箱即用**
-
-  支持 Bundle, Docker 两种启动方式
-
-- **速度飞起**
-
-  可以快速启动项目，多集群处理速度更快
-
-- **指标强大**
-
-  服务端渲染 (SSR) 支持，为 SEO 和高性能提供支持
-
-- **主题插件市场（WIP）**
-
-  主题多种开发方式，提供更多功能
-
-- **未来有望**
-
-  同时支持多种模板引擎和前后端分离，支持组件化开发
-
-- **插件系统**
-
-  支持创建属于你的插件，扩展 NEXT 原生服务的基本功能！
-
-- **更多功能**
-
-  NEXT 的未来等待你的发现和提交!
+~~[Documentation 文档](https://nx-docs.iucky.cn)｜ [Development Live Demo](#)~~
 
 ## 关于此项目 (core)
-
-This program (Core) is used to provide the personal space server *API service*. You can view the existing API interface provided by `Swagger`. 
-
-You can use the interface to develop your own personal space **the front end**. Looking forward to your results!
 
 此程序（core）是用来提供个人空间服务端API服务的，你可以通过 Swagger 来查看已提供的现有 API 接口。
 
 你可以使用接口来开发属于你的个人空间**前端** 期待你的成果！
-
-***无限进步！***
-
-## 注意：项目最近具有分支变动
-
-`refactor/mongo` 现在已命名为 `main`
-
-如果你在 *v0.4.0* 发布前有本地克隆仓库，你需要更新你的本地分支，命令参考如下：
-
-```bash
-git branch -m refactor/mongo main
-git fetch origin
-git branch -u origin/main main
-git remote set-head origin -a
-```
 
 
 ## 项目 Sponsors
@@ -93,6 +27,10 @@ git remote set-head origin -a
 感谢 **小沐** 的对项目大力支持
 
 感谢 **若志** 提供服务器支持
+
+## 活跃情况 Activity
+
+![Alt](https://repobeats.axiom.co/api/embed/c41f4aa5c6264c1db4ddd6c2120c0fca64dabcea.svg "Repobeats analytics image")
 
 ## 项目重构后所使用的技术栈
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,5 +1,5 @@
 import { Module } from "@nestjs/common";
-import { APP_FILTER, APP_INTERCEPTOR } from "@nestjs/core";
+import { APP_FILTER, APP_GUARD, APP_INTERCEPTOR } from "@nestjs/core";
 import { AppController } from "./app.controller";
 import { AllExceptionsFilter } from "./common/filters/any-exception.filter";
 import { HttpCacheInterceptor } from "./common/interceptors/cache.interceptor";
@@ -21,6 +21,8 @@ import { AggregateModule } from "./modules/aggregate/aggregate.module";
 import { LinksModule } from "./modules/links/links.module";
 import { ScheduleModule } from "@nestjs/schedule";
 import { InitModule } from "./modules/init/init.module";
+import { RolesGuard } from "./common/guard/roles.guard";
+import { AuthModule } from "./modules/auth/auth.module";
 
 @Module({
   imports: [
@@ -28,6 +30,7 @@ import { InitModule } from "./modules/init/init.module";
     CacheModule,
     DbModule,
     LoggerModule,
+    AuthModule,
     PostModule,
     UserModule,
     CategoryModule,
@@ -60,6 +63,10 @@ import { InitModule } from "./modules/init/init.module";
     {
       provide: APP_FILTER,
       useClass: AllExceptionsFilter,
+    },
+    {
+      provide: APP_GUARD,
+      useClass: RolesGuard,
     },
   ],
 })

--- a/src/common/decorator/auth.decorator.ts
+++ b/src/common/decorator/auth.decorator.ts
@@ -1,6 +1,6 @@
 import { UseGuards, applyDecorators } from "@nestjs/common";
 import { ApiBearerAuth, ApiUnauthorizedResponse } from "@nestjs/swagger";
-import { JWTAuthGuard } from "../guard/auth.guard";
+import { AuthGuard } from "../guard/auth.guard";
 
 export function Auth() {
   const decorators: (ClassDecorator | MethodDecorator | PropertyDecorator)[] =
@@ -8,7 +8,7 @@ export function Auth() {
 
   decorators.push(
     ApiBearerAuth(),
-    UseGuards(JWTAuthGuard),
+    UseGuards(AuthGuard),
     ApiUnauthorizedResponse({ description: "Unauthorized" })
   );
   return applyDecorators(...decorators);

--- a/src/common/decorator/cookie.decorator.ts
+++ b/src/common/decorator/cookie.decorator.ts
@@ -22,6 +22,6 @@ export const Cookies = createParamDecorator(
       cookieObj[key] = value;
     }
     );
-    return cookieObj;
+    return data ? cookieObj[data] : cookieObj;
   },
 );

--- a/src/common/decorator/cookie.decorator.ts
+++ b/src/common/decorator/cookie.decorator.ts
@@ -1,0 +1,27 @@
+/*
+ * @FilePath: /nx-core/src/common/decorator/cookie.decorator.ts
+ * @author: Wibus
+ * @Date: 2022-07-18 16:33:58
+ * @LastEditors: Wibus
+ * @LastEditTime: 2022-07-18 16:49:42
+ * Coding With IU
+ */
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const Cookies = createParamDecorator(
+  (data: string, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    // 获取 header 中的 cookie
+    const cookies = request.headers.cookie;
+    console.log(cookies);
+    // 解析 cookie
+    const cookie = cookies ? cookies.split('; ') : [];
+    const cookieObj = {};
+    cookie.forEach(item => {
+      const [key, value] = item.split('=');
+      cookieObj[key] = value;
+    }
+    );
+    return cookieObj;
+  },
+);

--- a/src/common/decorator/role.decorator.ts
+++ b/src/common/decorator/role.decorator.ts
@@ -3,7 +3,7 @@
  * @author: Wibus
  * @Date: 2022-06-07 22:07:30
  * @LastEditors: Wibus
- * @LastEditTime: 2022-07-17 21:29:07
+ * @LastEditTime: 2022-07-17 22:35:40
  * Coding With IU
  */
 import { ExecutionContext, createParamDecorator } from "@nestjs/common";
@@ -20,8 +20,6 @@ export const IsGuest = createParamDecorator(
 export const IsMaster = createParamDecorator( 
   (data: unknown, ctx: ExecutionContext) => { 
     const request = getNestExecutionContextRequest(ctx); // get the request from the execution context
-    console.log(request.isMaster)
     return request.isMaster; // return the value of the "isMaster" property
-    // how to make a request with "isMaster" property: curl -X GET http://localhost:3000/api/posts/ 
   }
 );

--- a/src/common/decorator/role.decorator.ts
+++ b/src/common/decorator/role.decorator.ts
@@ -3,7 +3,7 @@
  * @author: Wibus
  * @Date: 2022-06-07 22:07:30
  * @LastEditors: Wibus
- * @LastEditTime: 2022-06-07 22:07:30
+ * @LastEditTime: 2022-07-17 21:29:07
  * Coding With IU
  */
 import { ExecutionContext, createParamDecorator } from "@nestjs/common";
@@ -17,9 +17,11 @@ export const IsGuest = createParamDecorator(
   }
 );
 
-export const IsMaster = createParamDecorator(
-  (data: unknown, ctx: ExecutionContext) => {
-    const request = getNestExecutionContextRequest(ctx);
-    return request.isMaster;
+export const IsMaster = createParamDecorator( 
+  (data: unknown, ctx: ExecutionContext) => { 
+    const request = getNestExecutionContextRequest(ctx); // get the request from the execution context
+    console.log(request.isMaster)
+    return request.isMaster; // return the value of the "isMaster" property
+    // how to make a request with "isMaster" property: curl -X GET http://localhost:3000/api/posts/ 
   }
 );

--- a/src/common/guard/auth.guard.ts
+++ b/src/common/guard/auth.guard.ts
@@ -1,24 +1,60 @@
-import { CanActivate, ExecutionContext, Injectable } from "@nestjs/common";
-import { AuthGuard as _AuthGuard } from "@nestjs/passport";
-import { getNestExecutionContextRequest } from "~/transformers/get-req.transformer";
+/**
+ * @module common/guard/auth.guard
+ * @description 令牌验证的守卫
+ * @author Innei <https://innei.ren>
+ */
+import { isJWT } from 'class-validator'
+
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common'
+
+import { AuthService } from '~/modules/auth/auth.service'
+import { ConfigsService } from '~/modules/configs/configs.service'
+import { getNestExecutionContextRequest } from '~/transformers/get-req.transformer'
 
 /**
  * JWT auth guard
  */
 
 @Injectable()
-export class JWTAuthGuard extends _AuthGuard("jwt") implements CanActivate {
-  canActivate(context: ExecutionContext) {
-    const request = this.getRequest(context);
+export class AuthGuard implements CanActivate {
+  constructor(
+    protected readonly authService: AuthService,
+    protected readonly configs: ConfigsService,
+  ) {}
+  async canActivate(context: ExecutionContext): Promise<any> {
+    const request = this.getRequest(context)
 
-    if (typeof request.user !== "undefined") {
-      return true;
+    const query = request.query as any
+    const headers = request.headers
+    const Authorization: string =
+      headers.authorization || headers.Authorization || query.token
+
+    if (!Authorization) {
+      throw new UnauthorizedException('未登录')
     }
 
-    return super.canActivate(context);
+
+    const jwt = Authorization.replace(/[Bb]earer /, '')
+
+    if (!isJWT(jwt)) {
+      throw new UnauthorizedException('令牌无效')
+    }
+    const ok = await this.authService.jwtServicePublic.verify(jwt)
+    if (!ok) {
+      throw new UnauthorizedException('身份过期')
+    }
+
+    request.user = await this.configs.getMaster()
+    request.token = jwt
+    return true
   }
 
   getRequest(context: ExecutionContext) {
-    return getNestExecutionContextRequest(context);
+    return getNestExecutionContextRequest(context)
   }
 }

--- a/src/common/guard/roles.guard.ts
+++ b/src/common/guard/roles.guard.ts
@@ -1,0 +1,44 @@
+/**
+ * @module common/guard/spider.guard
+ * @description 禁止爬虫的守卫
+ * @author Innei <https://innei.ren>
+ */
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common'
+
+import { AuthService } from '~/modules/auth/auth.service'
+import { ConfigsService } from '~/modules/configs/configs.service'
+import { getNestExecutionContextRequest } from '~/transformers/get-req.transformer'
+
+import { AuthGuard } from './auth.guard'
+
+/**
+ * 区分游客和主人的守卫
+ */
+
+@Injectable()
+export class RolesGuard extends AuthGuard implements CanActivate {
+  constructor(
+    protected readonly authService: AuthService,
+    protected readonly configs: ConfigsService,
+  ) {
+    super(authService, configs)
+  }
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = this.getRequest(context)
+    let isMaster = false
+    try {
+      await super.canActivate(context)
+      isMaster = true
+      // eslint-disable-next-line no-empty
+    } catch {}
+
+    request.isGuest = !isMaster
+    request.isMaster = isMaster
+
+    return true
+  }
+
+  getRequest(context: ExecutionContext) {
+    return getNestExecutionContextRequest(context)
+  }
+}

--- a/src/common/guard/spider.guard.ts
+++ b/src/common/guard/spider.guard.ts
@@ -1,0 +1,43 @@
+/**
+ * @module common/guard/spider.guard
+ * @description 禁止爬虫的守卫
+ * @author Innei <https://innei.ren>
+ */
+ import { Observable } from 'rxjs'
+
+ import {
+   CanActivate,
+   ExecutionContext,
+   ForbiddenException,
+   Injectable,
+ } from '@nestjs/common'
+ 
+ import { isDev } from '~/global/env.global'
+ import { getNestExecutionContextRequest } from '~/transformers/get-req.transformer'
+ 
+ @Injectable()
+ export class SpiderGuard implements CanActivate {
+   canActivate(
+     context: ExecutionContext,
+   ): boolean | Promise<boolean> | Observable<boolean> {
+     if (isDev) {
+       return true
+     }
+ 
+     const request = this.getRequest(context)
+     const headers = request.headers
+     const ua: string = headers['user-agent'] || ''
+     const isSpiderUA =
+       !!ua.match(/(Scrapy|HttpClient|axios|python|requests)/i) &&
+       !ua.match(/(mx-space|rss|google|baidu|bing)/gi)
+     if (ua && !isSpiderUA) {
+       return true
+     }
+     throw new ForbiddenException(`爬虫是被禁止的哦，UA: ${ua}`)
+   }
+ 
+   getRequest(context: ExecutionContext) {
+     return getNestExecutionContextRequest(context)
+   }
+ }
+ 

--- a/src/modules/aggregate/aggregate.service.ts
+++ b/src/modules/aggregate/aggregate.service.ts
@@ -105,7 +105,9 @@ export class AggregateService {
     const combineTasks = await Promise.all([
       this.postService.model
         .find({
-          hide: false,
+          hide: false, // 只获取发布的文章
+          password: { $nq: null }, // 只获取没有密码的文章
+          rss: true, // 只获取公开RSS的文章
         })
         .populate("category")
         .then((list) =>
@@ -141,7 +143,11 @@ export class AggregateService {
 
     const [posts] = await Promise.all([
       this.postService.model
-        .find({ hide: false })
+        .find({ 
+          hide: false,
+          password: { $nq: null },
+          rss: true,
+         })
         .limit(10)
         .sort({ created: -1 })
         .populate("category"),
@@ -184,7 +190,11 @@ export class AggregateService {
   async getCounts() {
     const [posts, pages, categories, comments, allComments, unreadComments] =
       await Promise.all([
-        this.postService.model.countDocuments(),
+        this.postService.model.countDocuments({
+          hide: false,
+          password: { $nq: null },
+          rss: true,
+        }),
         this.pageService.model.countDocuments(),
         this.categoryService.model.countDocuments(),
         this.commentService.model.countDocuments({

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -1,4 +1,4 @@
-import { Module } from "@nestjs/common";
+import { Global, Module } from "@nestjs/common";
 import { JwtModule } from "@nestjs/jwt";
 import { PassportModule } from "@nestjs/passport";
 import { SECURITY } from "~/app.config";
@@ -19,6 +19,7 @@ const jwtModule = JwtModule.registerAsync({
     };
   },
 });
+@Global()
 @Module({
   imports: [PassportModule, jwtModule],
   providers: [AuthService, JwtStrategy],

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -14,6 +14,10 @@ export class AuthService {
     private readonly jwtService: JwtService
   ) {}
 
+  get jwtServicePublic() {
+    return this.jwtService;
+  }
+
   async signToken(_id: string) {
     const { authCode } = (await this.userModel
       .findById(_id)

--- a/src/modules/post/post.controller.ts
+++ b/src/modules/post/post.controller.ts
@@ -1,5 +1,4 @@
 import {
-  BadRequestException,
   Body,
   Controller,
   Delete,

--- a/src/modules/post/post.controller.ts
+++ b/src/modules/post/post.controller.ts
@@ -149,7 +149,7 @@ export class PostController {
 
   @Get("/:category/:slug")
   @ApiOperation({ summary: "根据分类名与自定义别名获取文章详情" })
-  async getByCategoryAndSlug(@Param() params: CategoryAndSlugDto, @IsMaster() isMaster: boolean, @Cookies() password: any) {
+  async getByCategoryAndSlug(@Param() params: CategoryAndSlugDto, @IsMaster() isMaster: boolean, @Cookies("password") password: any) {
     const { category, slug } = params;
     const categoryDocument = await this.postService.getCategoryBySlug(category);
     console.log(password);

--- a/src/modules/post/post.controller.ts
+++ b/src/modules/post/post.controller.ts
@@ -152,9 +152,7 @@ export class PostController {
   async getByCategoryAndSlug(@Param() params: CategoryAndSlugDto, @IsMaster() isMaster: boolean, @Cookies("password") password: any) {
     const { category, slug } = params;
     const categoryDocument = await this.postService.getCategoryBySlug(category);
-    console.log(password);
     if (password === undefined || !password) password = null;
-    console.log(password);
     if (!categoryDocument) {
       throw new NotFoundException("该分类不存在w");
     }

--- a/src/modules/post/post.dto.ts
+++ b/src/modules/post/post.dto.ts
@@ -3,7 +3,7 @@
  * @author: Wibus
  * @Date: 2022-06-21 23:59:41
  * @LastEditors: Wibus
- * @LastEditTime: 2022-06-21 23:59:42
+ * @LastEditTime: 2022-07-17 22:38:09
  * Coding With IU
  */
 
@@ -17,4 +17,8 @@ export class CategoryAndSlugDto {
   @IsString()
   @Transform(({ value: v }) => decodeURI(v))
   readonly slug: string;
+}
+
+export class PostVerifyDto {
+  readonly password: string | undefined | null;
 }

--- a/src/modules/post/post.model.ts
+++ b/src/modules/post/post.model.ts
@@ -90,7 +90,7 @@ export class PostModel extends WriteBaseModel {
       return null;
     }
   })
-  @ApiProperty({ description: "文章置顶" })
+  @ApiProperty({ description: "文章pin日期" })
   pin?: Date | null;
 
   @prop()
@@ -130,6 +130,24 @@ export class PostModel extends WriteBaseModel {
   @IsOptional()
   @ApiProperty({ description: '文章修改时间' })
   modified?: Date
+
+  @prop({ type: Boolean, default: false })
+  @IsOptional()
+  @IsBoolean()
+  @ApiProperty({ description: "文章是否隐藏" })
+  hide?: boolean;
+
+  @prop({ type: String, default: null })
+  @IsOptional()
+  @IsString()
+  @ApiProperty({ description: "文章加密密码（若填写则启动加密）" })
+  password?: string;
+
+  @prop({ type: Boolean, default: true })
+  @IsOptional()
+  @IsBoolean()
+  @ApiProperty({ description: "文章是否公开在RSS输出" })
+  rss?: boolean;
 }
 
 

--- a/src/modules/post/post.model.ts
+++ b/src/modules/post/post.model.ts
@@ -19,9 +19,9 @@ import { CategoryModel } from "../category/category.model";
 import { BeAnObject } from "@typegoose/typegoose/lib/types";
 import { Query } from "mongoose";
 import aggregatePaginate from 'mongoose-aggregate-paginate-v2'
+import { IsNilOrString } from "~/utils/validator/isNilOrString";
 
 @plugin(aggregatePaginate)
-@pre<PostModel>('findOne', autoPopulateRelated)
 @pre<PostModel>('findOne', autoPopulateCategory)
 @pre<PostModel>('find', autoPopulateCategory)
 @index({ slug: 1 })
@@ -139,9 +139,9 @@ export class PostModel extends WriteBaseModel {
 
   @prop({ type: String, default: null })
   @IsOptional()
-  @IsString()
+  @IsNilOrString()
   @ApiProperty({ description: "文章加密密码（若填写则启动加密）" })
-  password?: string;
+  password?: string | null;
 
   @prop({ type: Boolean, default: true })
   @IsOptional()
@@ -162,31 +162,6 @@ function autoPopulateCategory(
   next: () => void,
 ) {
   this.populate({ path: 'category' })
-  next()
-}
-
-function autoPopulateRelated(
-  this: Query<
-    any,
-    DocumentType<PostModel, BeAnObject>,
-    {},
-    DocumentType<PostModel, BeAnObject>
-  >,
-  next: () => void,
-) {
-  this.populate({
-    path: 'related',
-    select: [
-      'slug',
-      'title',
-      'summary',
-      'created',
-      'categoryId',
-      'modified',
-      '_id',
-      'id',
-    ],
-  })
   next()
 }
 

--- a/src/transformers/get-req.transformer.ts
+++ b/src/transformers/get-req.transformer.ts
@@ -4,5 +4,5 @@ import { UserModel } from "~/modules/user/user.model";
 export function getNestExecutionContextRequest(
   context: ExecutionContext
 ): FastifyRequest & { user?: UserModel } & Record<string, any> {
-  return context.switchToHttp().getRequest<FastifyRequest>();
+  return context.switchToHttp().getRequest<FastifyRequest>(); // get the request from the execution context
 }


### PR DESCRIPTION
感谢 @MYXXTS 的贡献

## 更改了什么？

新增了隐藏、加密、是否允许在RSS输出选项

## 需要注意什么？

1. 在原来的Post Route中，`posts/`需要**从请求头部中传入token**，才会输出 `hide`, `password`, `rss` 字段
2. 当填写了 `password` 字段后，将**自动开启加密**，若不想加密，只能删除 `password` 的值（~~别问为什么不做开关，问就是懒~~）
3. 在查找文章的接口中，若遇到了 **`hide` 字段为 `true`** 的文章，则**自动返回 `404`**（就别返回 `500`了，这样一眼看得出有问题）若遇到了具有 password 的文章则会返回 `500 + 提示输入密码`。传入密码**需要`query`传 `password` 的值**（~~因为`GET` 方法并没有所谓的`Body` 无法使用，但是这种用 `Query` 方法有点尴尬，这密码很容易就被知道了，但是目前暂时先这么做吧，期待大佬提出更好的方案~~ 感谢 @Truimo 等大佬的提议，现使用传入Cookie 进行判断）
4. `password` 字段一旦定义，**则会自动进行加密，不会保留明文密码**，一切皆以安全为好，传入的 `password` 同理，你传明文，同样也是**加密后进行比对的** （有个缺点，就是当你定义后，若你想要继续修改，你只能全部重新输入，无法在原有的密码上修改更新）
5. `password` 字段被定义后，游客使用的接口中，对有password定义的文章，`text, summary` 将会变为「此文章已被加密，请输入密码后查看」，至于为什么不做自定义（~~问就是懒，以后当作 performance 来做~~）
6. rss 输出中，若你将 `hide` 设定为 `true` 了，那么 rss 部分也会**自动隐藏**，但 `rss` 字段被设定后，**只是在 RSS 不输出罢**
7. `password` 字段一旦赋值，**加密的文章**将会在RSS聚合中**自动删除，无法显示**（~~不提供显示选项，第一我懒，第二加密文章无加密必要~~）（感谢 @MYXXTS 的提议）
8. 有待补充

---

closed #187 